### PR TITLE
TRUST-1935 Consuming optional command-line argument to override allowed WCU

### DIFF
--- a/emr-dynamodb-hive/pom.xml
+++ b/emr-dynamodb-hive/pom.xml
@@ -21,14 +21,14 @@
         <dependency>
             <groupId>com.amazon.emr</groupId>
             <artifactId>emr-dynamodb-hadoop</artifactId>
-            <version>${project.parent.version}</version>
+            <version>4.16.0</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.amazon.emr</groupId>
             <artifactId>emr-dynamodb-hadoop</artifactId>
-            <version>${project.parent.version}</version>
+            <version>4.2.0</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/emr-dynamodb-tools/pom.xml
+++ b/emr-dynamodb-tools/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.amazon.emr</groupId>
             <artifactId>emr-dynamodb-hadoop</artifactId>
-            <version>${project.parent.version}</version>
+            <version>4.16.0</version>
         </dependency>
 
         <dependency>
@@ -61,10 +61,23 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
-                    <maxAllowedViolations>0</maxAllowedViolations>
+
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBImport.java
+++ b/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBImport.java
@@ -73,6 +73,18 @@ public class DynamoDBImport extends Configured implements Tool {
       }
     }
     setTableProperties(jobConf, tableName, writeRatio);
+    int writeThroughput = 0;
+    if (args.length >= 4) {
+      String val = args[3];
+      try {
+        writeThroughput = Integer.parseInt(val);
+        jobConf.set(DynamoDBConstants.WRITE_THROUGHPUT, Integer.toString(writeThroughput));
+        System.out.println("Overridden WRITE_THROUGHPUT to " + writeThroughput);
+      } catch (Exception e) {
+        printUsage("Could not parse write throughput (value: " + val + ")");
+        return -1;
+      }
+    }
 
     Date startTime = new Date();
     System.out.println("Job started: " + startTime);

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
         <java.version>1.8</java.version>
         <aws-java-sdk.version>1.11.475</aws-java-sdk.version>
         <hadoop.version>2.7.3</hadoop.version>
-        <hive1.version>1.0.0</hive1.version>
+        <hive1.version>2.3.0</hive1.version>
         <hive1.2.version>1.2.1</hive1.2.version>
-        <hive2.version>2.3.0</hive2.version>
+        <hive2.version>1.0.0</hive2.version>
         <!-- Use the more recent version as it will be more likely to
         have all the interfaces/classes we need for shims to work -->
         <hive.version>${hive2.version}</hive.version>


### PR DESCRIPTION
*Issue #, 
The problem is [emr-dynamodb-connector](https://github.com/awslabs/emr-dynamodb-connector/blob/master/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBImport.java#L96), reading write capacity only at the time of startup for BILLING_MODE_PROVISIONED  latter it is not picking updated the write capacity in case of autoscaling enabled. Which is leading to under utilisation of provisioned write capacity. 

*Description of changes:
Starting consuming optional command-line argument to override allowed WCU  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
